### PR TITLE
Fix4

### DIFF
--- a/routes/claims.js
+++ b/routes/claims.js
@@ -69,7 +69,16 @@ router.post('/', async (req, res, next) => {
       mosaicService.mosaicsAmountViewFromAddress(sanitizedAddress)
         .pipe(
           op.mergeMap(_ => _),
-          op.filter(mo => mo.fullName() === 'nem:xem')
+          op.filter(mo => mo.fullName() === 'nem:xem'),
+          op.defaultIfEmpty(),
+          op.catchError(err => {
+            const response = JSON.parse(err.response.text);
+            if (response.code == 'ResourceNotFound') {
+              return rx.of('ResourceNotFound')
+            } else {
+              return rx.throwError('Something wrong with MosaicService response')
+            }
+          }),
         ),
       accountHttp.outgoingTransactions(faucetAccount)
         .pipe(

--- a/routes/claims.js
+++ b/routes/claims.js
@@ -18,6 +18,7 @@ const ENOUGH_BALANCE = parseInt(process.env.ENOUGH_BALANCE || config.enoughBalan
 const MAX_UNCONFIRMED = parseInt(process.env.MAX_UNCONFIRMED || config.maxUnconfirmed)
 const WAIT_HEIGHT = parseInt(process.env.WAIT_HEIGHT || config.waitHeight)
 const API_URL = `${process.env.API_HOST}:${process.env.API_PORT}`
+const RESOURCE_NOT_FOUND = 'ResourceNotFound';
 
 const faucetAccount = nem.Account.createFromPrivateKey(
   process.env.PRIVATE_KEY,
@@ -73,8 +74,8 @@ router.post('/', async (req, res, next) => {
           op.defaultIfEmpty(),
           op.catchError(err => {
             const response = JSON.parse(err.response.text);
-            if (response.code == 'ResourceNotFound') {
-              return rx.of('ResourceNotFound')
+            if (response.code == RESOURCE_NOT_FOUND) {
+              return rx.of(null)
             } else {
               return rx.throwError('Something wrong with MosaicService response')
             }
@@ -118,7 +119,7 @@ router.post('/', async (req, res, next) => {
           return
         }
 
-        if(false && xemClaimerOwned.amount.compact() >= ENOUGH_BALANCE) {
+        if(xemClaimerOwned !== null && xemClaimerOwned.amount.compact() >= ENOUGH_BALANCE) {
           console.debug(`claimer balance => %d`, xemClaimerOwned.amount.compact())
           req.flash('error', `Your account already have enougth balance => (%s)`, xemClaimerOwned.relativeAmount())
           res.redirect(`/?${query}`)

--- a/routes/index.js
+++ b/routes/index.js
@@ -57,7 +57,10 @@ router.get('/', function(req, res, next) {
           amount: amount,
           faucetAddress: data.account.address.pretty(),
           faucetAmount: data.mosaics[0].relativeAmount(),
-          recaptcha_secret: process.env.RECAPTCHA_CLIENT_SECRET
+          recaptcha_secret: process.env.RECAPTCHA_CLIENT_SECRET,
+          network: process.env.NETWORK,
+          apiHost: process.env.API_HOST,
+          apiPort: process.env.API_PORT
         }
       ),
       err => next,

--- a/views/index.pug
+++ b/views/index.pug
@@ -51,7 +51,7 @@ block content
       .col.m12
         h3 Readme
         ul
-          li This is "MIJIN_TEST XEM faucet" on "http://catapult-test.44uk.net:3000".
+          li This is "#{network} XEM faucet" on "#{apiHost}:#{apiPort}".
           li You can get XEM randomly from #{xemMin} to #{xemMax}.
           li This is an experimental server, the spec can be change without notice.
           li Please send back XEM when you need no longer need.


### PR DESCRIPTION
1. Account issue with no transactions
If there are no transactions related to claimer, MosaicService returns 403 "ResourceNotFound". Therefore, Observable throws exception. 
However, we will not regard this case as an exception.
For example, if reason of exception is "ResourceNotFound", Observable emits something item.
"catchError" enables it.
I want the item to be an instance of MosaicAmountView, but it is difficult for me.

2. Account issue with no mosaics
If claimer has no mosaics, Observable of MosaicService emits no items.
Therefore claimer request results timed out.
In this case, default items are required.
"defaultIfEmpty" enables it.

3. enough balance
By solving the previous two, it is possible to check the balance of the claimer.

4. misc
Some environment variables (networkType, host, port) are used in readme description.